### PR TITLE
Use USER_AGENT const from reqwest library

### DIFF
--- a/src/site.rs
+++ b/src/site.rs
@@ -59,7 +59,7 @@ impl<'a> Website for Site<'a>{
        let client = reqwest::Client::new();
        let res = client
             .get(self.url)
-            .header("USER_AGENT", "reqwest")
+            .header(reqwest::header::USER_AGENT, "reqwest")
             .send().await?.text().await?;
        if !res.trim().is_empty(){
         self.content = res;


### PR DESCRIPTION
Some websites will issue a `403` if the user agent is specified with capital letters. I changed it to use the constant that the `reqwest` library already defines.